### PR TITLE
initial implementation of Neoverse N1 support

### DIFF
--- a/osaca/data/n1.yml
+++ b/osaca/data/n1.yml
@@ -1,0 +1,771 @@
+osaca_version: 0.3.3
+micro_architecture: Arm Neoverse N1 
+arch_code: n1
+isa: AArch64
+ROB_size: 128                   # wikichip
+retired_uOps_per_cycle: 8       # wikichip
+scheduler_size: 120             # wikichip
+hidden_loads: false
+load_latency: {w: 4.0, x: 4.0, b: 4.0, h: 4.0, s: 4.0, d: 5.0, q: 6.0, v: 5.0, z: 4.0}
+load_throughput:
+- {base: x, index: ~, offset: ~, scale: 1, pre-indexed: false, post-indexed: false, port_pressure:   [[1, '67']]}
+- {base: x, index: ~, offset: imd, scale: 1, pre-indexed: false, post-indexed: true, port_pressure:  [[1, '67'], [1, '123']]}
+- {base: x, index: ~, offset: imd, scale: 1, pre-indexed: false, post-indexed: false, port_pressure: [[1, '67']]}
+- {base: x, index: ~, offset: imd, scale: 1, pre-indexed: true, post-indexed: true, port_pressure:   [[1, '67'], [1, '123']]}
+- {base: x, index: ~, offset: imd, scale: 1, pre-indexed: true, post-indexed: false, port_pressure:  [[1, '67'], [1, '123']]}
+- {base: x, index: x, offset: ~, scale: 1, pre-indexed: false, post-indexed: true, port_pressure:    [[1, '67'], [1, '123']]}
+- {base: x, index: x, offset: ~, scale: 1, pre-indexed: false, post-indexed: false, port_pressure:   [[1, '67']]}
+- {base: x, index: x, offset: ~, scale: 1, pre-indexed: true, post-indexed: true, port_pressure:     [[1, '67'], [1, '123']]}
+- {base: x, index: x, offset: ~, scale: 1, pre-indexed: true, post-indexed: false, port_pressure:    [[1, '67'], [1, '123']]}
+- {base: x, index: x, offset: imd, scale: 1, pre-indexed: false, post-indexed: true, port_pressure:  [[1, '67'], [1, '123']]}
+- {base: x, index: x, offset: imd, scale: 1, pre-indexed: false, post-indexed: false, port_pressure: [[1, '67']]}
+- {base: x, index: x, offset: imd, scale: 1, pre-indexed: true, post-indexed: true, port_pressure:   [[1, '67'], [1, '123']]}
+- {base: x, index: x, offset: imd, scale: 1, pre-indexed: true, post-indexed: false, port_pressure:  [[1, '67'], [1, '123']]}
+load_throughput_default: [[1, '67']]
+store_throughput: []
+store_throughput_default: [[1, '56'], [1, '67']]
+ports: ['0', '1', '2', '3', '4', '4DV', '5', '6', '7']
+port_model_scheme: |
+  +----------------------------------------------------------------------------+
+  |                                120 entries                                 |
+  +----------------------------------------------------------------------------+
+    0 |BR   1 |IS0  2 |IS1  3 |IM0     4 |FP0     5 |FP1     6 |LDST   7 |LDST
+      \/      \/      \/      \/         \/         \/         \/        \/
+   +------+ +-----+ +-----+ +-----+  +--------+ +--------+  +-------+ +-------+ 
+   |Branch| | INT | | INT | | INT |  | FP ALU | | FP ALU |  |  AGU  | |  AGU  |
+   +------+ | ALU | | ALU | | ALU |  +--------+ +--------+  +-------+ +-------+
+            +-----+ +-----+ +-----+  +--------+ +--------+  +-------+ +-------+
+                    +-----+ +-----+  | FP MUL | | FP MUL |  |LD DATA| |LD DATA|
+                    | ST  | | INT |  +--------+ +--------+  +-------+ +-------+
+                    | INT | | MUL |  +--------+ +---------+
+                    +-----+ +-----+  | FP DIV | |SIMD SHFT|
+                            +-----+  +--------+ +---------+
+                            | INT |  +--------+ +--------+
+                            | DIV |  |  FMA   | |  FMA   |
+                            +-----+  +--------+ +--------+
+                            +-----+  +--------+ +--------+
+                            |SHIFT|  | ST SIMD| | ST SIMD|
+                            +-----+  |  DATA  | |  DATA  |
+                            +-----+  +--------+ +--------+
+                            | ST  |
+                            | INT |
+                            +-----+
+instruction_forms:
+- name: add
+  operands:
+  - class: register
+    prefix: x
+  - class: register
+    prefix: x
+  - class: register
+    prefix: x
+  throughput: 0.33333333
+  latency: 1.0  # 	1*p123
+  port_pressure: [[1, '123']]
+- name: add
+  operands:
+  - class: register
+    prefix: x
+  - class: register
+    prefix: x
+  - class: immediate
+    imd: int
+  throughput: 0.33333333
+  latency: 1.0  # 	1*p123
+  port_pressure: [[1, '123']]
+- name: adds
+  operands:
+  - class: register
+    prefix: x 
+  - class: register
+    prefix: x
+  - class: immediate
+    imd: int
+  throughput: 0.33333333
+  latency: 1.0  # 	1*p123
+  port_pressure: [[1, '132']]
+- name: b.ne
+  operands:
+  - class: identifier
+  throughput: 1.0
+  latency: 0.0
+  port_pressure: [[1, '0']]
+- name: b.gt
+  operands:
+  - class: identifier
+  throughput: 1.0
+  latency: 0.0
+  port_pressure: [[1, '0']]
+- name: bne
+  operands:
+  - class: identifier
+  throughput: 1.0
+  latency: 0.0
+  port_pressure: [[1, '0']]
+- name: cmp
+  operands:
+  - class: register
+    prefix: w
+  - class: immediate
+    imd: int
+  throughput: 0.33333333
+  latency: 1.0  # 	1*p123
+  port_pressure: [[1, '123']]
+- name: cmp
+  operands:
+  - class: register
+    prefix: x
+  - class: register
+    prefix: x
+  throughput: 0.3333333
+  latency: 1.0  # 	1*p123
+  port_pressure: [[1, '123']]
+- name: dup
+  operands:
+  - class: register
+    prefix: d
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fadd
+  operands:
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fadd
+  operands:
+  - class: register
+    prefix: d
+    width: '*'
+  - class: register
+    prefix: d
+    width: '*'
+  - class: register
+    prefix: d
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fadd
+  operands:
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fdiv
+  operands:
+  - class: register
+    prefix: v
+    shape: s
+    width: 128
+  - class: register
+    prefix: v
+    shape: s
+    width: 128
+  - class: register
+    prefix: v
+    shape: s
+    width: 128
+  throughput: 6.0
+  latency: 8.0  # 	1*p4+6*p4DV
+  port_pressure: [[1, '4'], [6, [4DV]]]
+- name: fdiv
+  operands:
+  - class: register
+    prefix: v
+    shape: d
+    width: 128
+  - class: register
+    prefix: v
+    shape: d
+    width: 128
+  - class: register
+    prefix: v
+    shape: d
+    width: 128
+  throughput: 10.0
+  latency: 12.0  # 	1*p4+10*p4DV
+  port_pressure: [[4, '0'], [10, [4DV]]]
+- name: fmla
+  operands:
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fmla
+  operands:
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fmov
+  operands:
+  - {class: register, prefix: s}
+  - {class: immediate, imd: double}
+  latency: ~  # 	1*p45
+  port_pressure: [[1, '45']]
+  throughput: 0.5
+- name: fmul
+  operands:
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  throughput: 0.5
+  latency: 3.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fmul
+  operands:
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  throughput: 0.5
+  latency: 3.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fmul
+  operands:
+  - class: register
+    prefix: d
+  - class: register
+    prefix: d
+  - class: register
+    prefix: d
+  throughput: 0.5
+  latency: 3.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: frecpe
+  operands:
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  throughput: 2.0
+  latency: 4.0  # 	1*p4
+  port_pressure: [[2, '4']]
+- name: frecpe
+  operands:
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  throughput: 1.0
+  latency: 3.0  # 	1*p4
+  port_pressure: [[1, '4']]
+- name: fsub
+  operands:
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  - class: register
+    prefix: v
+    shape: s
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: fsub
+  operands:
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  - class: register
+    prefix: v
+    shape: d
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: ldp
+  operands:
+  - class: register
+    prefix: d
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: imd
+    index: ~
+    scale: 1
+    pre-indexed: false
+    post-indexed: false
+  throughput: 1.0
+  latency: 5.0  # 	2*p67, from n1 opt guide
+  port_pressure: [[2, '67']]
+- name: ldp
+  operands:
+  - class: register
+    prefix: d
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: imd
+    index: ~
+    scale: 1
+    pre-indexed: false
+    post-indexed: true
+  throughput: 1.0
+  latency: 5.0  # 	2*p67+1*p123, from n1 opt guide
+  port_pressure: [[2, '67'], [1, '123']]
+- name: ldp
+  operands:
+  - class: register
+    prefix: q
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: 1
+    pre-indexed: false
+    post-indexed: false
+  throughput: 1.0
+  latency: 7.0  # 	2*p67, from n1 opt guide
+  port_pressure: [[2, '67']]
+- name: ldp
+  operands:
+  - class: register
+    prefix: q
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: ~
+    index: ~
+    scale: 1
+    pre-indexed: false
+    post-indexed: true
+  throughput: 1.0
+  latency: 7.0  # 	2*p67+1*p123, from n1 opt guide
+  port_pressure: [[2, '56'], [1, '123']]
+- name: ldp
+  operands:
+  - class: register
+    prefix: q
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: false
+  throughput: 1.0
+  latency: 7.0  # 	2*p67
+  port_pressure: [[2, '67']]
+- name: ldp
+  operands:
+  - class: register
+    prefix: q
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: true
+    post-indexed: false
+  throughput: 1.0
+  latency: 7.0  # 	2*p67+1*p123
+  port_pressure: [[2, '67'], [1, '123']]
+- name: ldp
+  operands:
+  - class: register
+    prefix: d
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: true
+  throughput: 1.0
+  latency: 5.0  # 	2*p67+1*p123
+  port_pressure: [[2, '67'], [1, '123']]
+- name: ldur    # JL: assumed from n1 opt guide
+  operands:
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    post-indexed: false
+    pre-indexed: false
+  throughput: 0.5
+  latency: 6.0  # 	1*p67
+  port_pressure: [[1, '67']]
+- name: ldr
+  operands:
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    post-indexed: false
+    pre-indexed: false
+  throughput: 0.5
+  latency: 6.0  # 	1*p67
+  port_pressure: [[1, '67']]
+- name: ldr
+  operands:
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    post-indexed: false
+    pre-indexed: false
+  throughput: 0.5
+  latency: 5.0  # 	1*p67
+  port_pressure: [[1, '67']]
+- name: ldr
+  operands:
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: imd
+    index: '*'
+    scale: '*'
+    post-indexed: false
+    pre-indexed: false
+  throughput: 0.5
+  latency: 5.0  # 	1*p67
+  port_pressure: [[1, '67']]
+- name: ldr
+  operands:
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    post-indexed: false
+    pre-indexed: false
+  throughput: 0.5
+  latency: 5.0  # 	1*p67
+  port_pressure: [[1, '67']]
+- name: ldr
+  operands:
+  - class: register
+    prefix: x
+  - class: register
+    prefix: x
+  throughput: 0.0
+  latency: 0.0
+  port_pressure: []
+- name: ldr
+  operands:
+  - class: register
+    prefix: q
+  - class: register
+    prefix: q
+  throughput: 0.0
+  latency: 0.0
+  port_pressure: []
+- name: ldr
+  operands:
+  - class: register
+    prefix: d
+  - class: register
+    prefix: d
+  throughput: 0.0
+  latency: 0.0
+  port_pressure: []
+- name: mov
+  operands:
+  - class: register
+    prefix: x
+  - class: register
+    prefix: x
+  throughput: 0.25
+  latency: 1.0  # 	1*p3456
+  port_pressure: [[1, '3456']]
+- name: mov
+  operands:
+  - class: register
+    prefix: v
+    shape: b
+    width: '*'
+  - class: register
+    prefix: v
+    shape: b
+    width: '*'
+  throughput: 0.5
+  latency: 2.0  # 	1*p45
+  port_pressure: [[1, '45']]
+- name: stp
+  operands:
+  - class: register
+    prefix: d
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: false
+  throughput: 1.0
+  latency: 0  # 	2*p45+1*p67
+  port_pressure: [[2, '45'], [1, '67']]
+- name: stp
+  operands:
+  - class: register
+    prefix: q
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: true
+  throughput: 1.0
+  latency: 0  # 	2*p45+2*p67+1*123
+  port_pressure: [[2, '45'], [2, '67'], [1, '123']]
+- name: stp
+  operands:
+  - class: register
+    prefix: q
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: false
+  throughput: 1.0
+  latency: 0  # 	2*p45+2*p67
+  port_pressure: [[2, '45'], [2, '67']]
+- name: stur # JL: assumed from n1 opt guide
+  operands:
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: false
+  throughput: 0.5
+  latency: 0  # 	1*p67+1*p23
+  port_pressure: [[1, '56'], [1, '23']]
+- name: stur # JL: assumed from n1 opt guide
+  operands:
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: false
+  throughput: 1.0
+  latency: 0  # 	2*p67+1*p45
+  port_pressure: [[2, '67'], [1, '45']]
+- name: str
+  operands:
+  - class: register
+    prefix: x
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: false
+  throughput: 0.5
+  latency: 0  # 	1*p67+1*p23
+  port_pressure: [[1, '56'], [1, '23']]
+- name: str
+  operands:
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: false
+  throughput: 0.5
+  latency: 0  # 	1*p67+1*p45
+  port_pressure: [[1, '67'], [1, '45']]
+- name: str
+  operands:
+  - class: register
+    prefix: d
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: true
+  throughput: 0.5
+  latency: 0  # 	1*p67+1*p45+1*p123
+  port_pressure: [[1, '67'], [1, '45'], [1, '123']]
+- name: str
+  operands:
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: 1
+    pre-indexed: false
+    post-indexed: false
+  throughput: 1.0
+  latency: 0  # 	2*p67+1*p45
+  port_pressure: [[1, '67'], [1, '45']]
+- name: str
+  operands:
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: true
+  throughput: 1.0
+  latency: 0  # 	1*p67+1*p45+1*123
+  port_pressure: [[1, '67'], [1, '45'], [1, '123']]
+- name: str
+  operands:
+  - class: register
+    prefix: x
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: false
+    post-indexed: true
+  throughput: 1.0
+  latency: 0  # 	1*p67+1*p23+1*p123
+  port_pressure: [[1, '67'], [1, '23'], [1, '123']]
+- name: sub
+  operands:
+  - class: register
+    prefix: w
+  - class: register
+    prefix: w
+  - class: immediate
+    imd: int
+  throughput: 0.33333333
+  latency: 1.0  # 	1*p123
+  port_pressure: [[1, '123']]

--- a/osaca/osaca.py
+++ b/osaca/osaca.py
@@ -17,7 +17,7 @@ MODULE_DATA_DIR = os.path.join(
 )
 LOCAL_OSACA_DIR = os.path.join(os.path.expanduser('~') + '/.osaca/')
 DATA_DIR = os.path.join(LOCAL_OSACA_DIR, 'data/')
-SUPPORTED_ARCHS = ['SNB', 'IVB', 'HSW', 'BDW', 'SKX', 'CSX', 'ZEN1', 'ZEN2', 'TX2']
+SUPPORTED_ARCHS = ['SNB', 'IVB', 'HSW', 'BDW', 'SKX', 'CSX', 'ZEN1', 'ZEN2', 'TX2', 'N1']
 
 
 # Stolen from pip
@@ -71,7 +71,7 @@ def create_parser(parser=None):
     parser.add_argument(
         '--arch',
         type=str,
-        help='Define architecture (SNB, IVB, HSW, BDW, SKX, CSX, ZEN1, ZEN2, TX2).',
+        help='Define architecture (SNB, IVB, HSW, BDW, SKX, CSX, ZEN1, ZEN2, TX2, N1).',
     )
     parser.add_argument(
         '--fixed',

--- a/osaca/semantics/hw_model.py
+++ b/osaca/semantics/hw_model.py
@@ -241,6 +241,7 @@ class MachineModel(object):
         """Return ISA for given micro-arch ``arch``."""
         arch_dict = {
             'tx2': 'aarch64',
+            'n1': 'aarch64',
             'zen1': 'x86',
             'zen+': 'x86',
             'zen2': 'x86',


### PR DESCRIPTION
First tests with the model showed reasonable behavior and results:

kernel | arch | unrolling x SIMD | compiler | measured | osaca_tp | osaca_cp | osaca_lcd | Accuracy
-- | -- | -- | -- | -- | -- | -- | -- | --
copy | n1 | 8 x 2 | gcc | 8.01 | 8.00 | 7.00 | 1.00 | 0.999
add | n1 | 8 x 2 | gcc | 12.01 | 12.00 | 9.00 | 0.00 | 0.999
update | n1 | 8 x 2 | gcc | 8.32 | 8.00 | 18.00 | 1.00 | 0.962
sum_reduction | n1 | 8 x 2 | gcc -Ofast | 5.81 | 4.12 | 24.00 | 16.00 | 0.709
sum_reduction | n1 | 16 x 1 | gcc -O3 | 32.01 | 16.00 | 40.00 | 32.00 | 1.000
daxpy | n1 | 8 x 2 | gcc | 12.02 | 12.00 | 9.00 | 0.00 | 0.998
triad | n1 | 8 x 2 | gcc | 12.01 | 12.00 | 9.00 | 0.00 | 0.999
striad | n1 | 8 x 2 | gcc | 16.02 | 16.00 | 9.00 | 0.00 | 0.999
gs | n1 | 4 x 1 | gcc | 29.62 | 10.00 | 42.00 | 28.00 | 0.945
j2d | n1 | 4 x 2 | gcc | 11.40 | 10.00 | 16.00 | 0.00 | 0.877

Nonetheless, general adjustments for AArch64 must be made:
- Better LCD detection
- `width` attribute must be added to vector instruction forms since latency/throughput may differ for different register widths, e.g. `.2s` (64bit) and `.4s` (128bit)
- SVE support! 