### PR TITLE
att parser: workaround for crash with "jg,pt" mnemonic

### DIFF
--- a/osaca/parser/parser_x86att.py
+++ b/osaca/parser/parser_x86att.py
@@ -288,7 +288,7 @@ class ParserX86ATT(BaseParser):
             operands.append(self.process_operand(result['operand4']))
         return_dict = AttrDict(
             {
-                self.INSTRUCTION_ID: result['mnemonic'],
+                self.INSTRUCTION_ID: result['mnemonic'].split(',')[0],
                 self.OPERANDS_ID: operands,
                 self.COMMENT_ID: ' '.join(result[self.COMMENT_ID])
                 if self.COMMENT_ID in result

--- a/osaca/parser/parser_x86att.py
+++ b/osaca/parser/parser_x86att.py
@@ -158,7 +158,7 @@ class ParserX86ATT(BaseParser):
         # Instructions
         # Mnemonic
         mnemonic = pp.ZeroOrMore(pp.Literal('data16') | pp.Literal('data32')) + pp.Word(
-            pp.alphanums
+            pp.alphanums + ','
         ).setResultsName('mnemonic')
         # Combine to instruction form
         operand_first = pp.Group(


### PR DESCRIPTION
found some 'jg,pt' in icc/mkl generated binaries which crashed the
parser, here an example:
`  dd8ccd:       3e 7f 90                jg,pt  dd8c60 <mkl_blas_avx2_dtrsm_kernel_ru_0+0x360>`

(have not verified if this hotfix doesnt create problems with other assembly instructions)