### PR TITLE
fix a bug when 'mov' is the last instruction

### DIFF
--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -225,7 +225,7 @@ class KernelDG(nx.DiGraph):
                 node["latency_cp"] = self.dg.edges[(s, d)]["latency"]
                 path_latency += node["latency_cp"]
             # add latency for last instruction
-            node = self._get_node_by_lineno(longest_path[-1])
+            node = self._get_node_by_lineno(int(longest_path[-1]))
             node["latency_cp"] = node["latency"]
             if max_latency_instr["latency"] > path_latency:
                 max_latency_instr["latency_cp"] = float(max_latency_instr["latency"])

--- a/osaca/semantics/marker_utils.py
+++ b/osaca/semantics/marker_utils.py
@@ -138,7 +138,7 @@ def find_marked_section(
                     index_start = i + 1
                 elif comments["end"] == line.comment:
                     index_end = i
-            elif line.instruction in mov_instr and lines[i + 1].directive is not None:
+            elif line.instruction in mov_instr and len(lines) > i + 1 and lines[i + 1].directive is not None:
                 source = line.operands[0 if not reverse else 1]
                 destination = line.operands[1 if not reverse else 0]
                 # instruction pair matches, check for operands


### PR DESCRIPTION
when 'mov' is the last  instruction, index will be out of range