### PR TITLE
Support for flags and conditional ops on AArch64

### DIFF
--- a/osaca/data/a64fx.yml
+++ b/osaca/data/a64fx.yml
@@ -1,4 +1,4 @@
-osaca_version: 0.3.3
+osaca_version: 0.5.0
 micro_architecture: Fujitsu A64FX
 arch_code: a64fx
 isa: AArch64
@@ -25,6 +25,7 @@ load_throughput:
 load_throughput_default: [[1, '56'], [1, ['5D', '6D']]]
 store_throughput: []
 store_throughput_default: [[1, '5'], [1, '6']]
+p_index_latency: 1
 #store_throughput_multiplier: {w: 1.0, x: 1.0, b: 1.0, h: 1.0, s: 1.0, d: 1.0, q: 1.0, v: 2.0, z: 2.0}
 ports: ['0', 0DV, '1', '2', '3', '4', '5', 5D, '6', 6D, '7']
 port_model_scheme: |
@@ -356,27 +357,62 @@ instruction_forms:
   throughput: 0.5
   latency: 1.0  # 	1*p34
   port_pressure: [[1, '34']]
-- name: csel
+- name: [ccmp, ccmn]
   operands:
   - class: register
-    prefix: x
+    prefix: "*"
+  - class: immediate
+    imd: int
+  - class: immediate
+    imd: int
+  - class: condition
+    ccode: "*"
+  throughput: 1.0
+  latency: 2.0  # 	2*p3 | 2*p4
+  port_pressure: [[2, '34']]
+- name: [ccmp, ccmn]
+  operands:
   - class: register
-    prefix: x
+    prefix: "*"
   - class: register
-    prefix: x
-  - class: identifier
+    prefix: "*"
+  - class: immediate
+    imd: int
+  - class: condition
+    ccode: "*"
+  throughput: 1.0
+  latency: 2.0  # 	2*p3 | 2*p4
+  port_pressure: [[2, '34']]
+- name: [csel, csinc, csinv, csneg]
+  operands:
+  - class: register
+    prefix: "*"
+  - class: register
+    prefix: "*"
+  - class: register
+    prefix: "*"
+  - class: condition
+    ccode: "*"
   throughput: 0.5
   latency: 1.0  # 	1*p34
   port_pressure: [[1, '34']]
-- name: csel
+- name: [cinc, cinv, cneg]
   operands:
   - class: register
-    prefix: w
+    prefix: "*"
   - class: register
-    prefix: w
+    prefix: "*"
+  - class: condition
+    ccode: "*"
+  throughput: 0.5
+  latency: 1.0  # 	1*p34
+  port_pressure: [[1, '34']]
+- name: [cset, csetm]
+  operands:
   - class: register
-    prefix: w
-  - class: identifier
+    prefix: "*"
+  - class: condition
+    ccode: "*"
   throughput: 0.5
   latency: 1.0  # 	1*p34
   port_pressure: [[1, '34']]
@@ -2152,6 +2188,22 @@ instruction_forms:
   throughput: 2.0
   latency: 0  # 	2*p56+2*p0
   port_pressure: [[2, '5'], [2,'6'], [2, '0']]
+- name: stp
+  operands:
+  - class: register
+    prefix: q
+  - class: register
+    prefix: q
+  - class: memory
+    base: x
+    offset: '*'
+    index: '*'
+    scale: '*'
+    pre-indexed: true
+    post-indexed: false
+  throughput: 2.0
+  latency: 0  # 	2*p56+2*p0+1*0234
+  port_pressure: [[2, '5'], [2,'6'], [2, '0'], [1, '0234']]
 - name: stp
   operands:
   - class: register

--- a/osaca/data/a64fx.yml
+++ b/osaca/data/a64fx.yml
@@ -187,11 +187,22 @@ instruction_forms:
 - name: adds
   operands:
   - class: register
-    prefix: x 
+    prefix: "*"
   - class: register
-    prefix: x
+    prefix: "*"
   - class: immediate
     imd: int
+  throughput: 0.5
+  latency: 1.0  # 	1*p34
+  port_pressure: [[1, '34']]
+- name: adds
+  operands:
+  - class: register
+    prefix: "*"
+  - class: register
+    prefix: "*"
+  - class: register
+    prefix: "*"
   throughput: 0.5
   latency: 1.0  # 	1*p34
   port_pressure: [[1, '34']]

--- a/osaca/data/isa/aarch64.yml
+++ b/osaca/data/isa/aarch64.yml
@@ -1,4 +1,4 @@
-osaca_version: 0.3.7
+osaca_version: 0.5.0
 isa: "AArch64"
 # Contains all operand-irregular instruction forms OSACA supports for AArch64.
 # Operand-regular for a AArch64 instruction form with N operands in the shape of
@@ -802,14 +802,14 @@ instruction_forms:
         source: true
         destination: true
       - class: identifier
-        source: false 
+        source: false
         destination: false
       - class: identifier
-        source: false 
+        source: false
         destination: false
       - class: immediate
         imd: int
-        source: false 
+        source: false
         destination: false
     - name: fmla
       operands:
@@ -1078,7 +1078,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "eq"
+          ccode: "eq"
           source: true
           destination: false
       hidden_operands:
@@ -1097,7 +1097,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "ne"
+          ccode: "ne"
           source: true
           destination: false
       hidden_operands:
@@ -1116,7 +1116,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "cs"
+          ccode: "cs"
           source: true
           destination: false
       hidden_operands:
@@ -1135,7 +1135,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "hs"
+          ccode: "hs"
           source: true
           destination: false
       hidden_operands:
@@ -1154,7 +1154,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "cc"
+          ccode: "cc"
           source: true
           destination: false
       hidden_operands:
@@ -1173,7 +1173,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "lo"
+          ccode: "lo"
           source: true
           destination: false
       hidden_operands:
@@ -1192,30 +1192,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "hi"
-          source: true
-          destination: false
-      hidden_operands:
-        - class: flag
-          name: "Z"
-          source: true
-          destination: false
-        - class: flag
-          name: "C"
-          source: true
-          destination: false
-    - name: [cinc, cinv, cneg]
-      operands:
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: register
-          prefix: "*"
-          source: true
-          destination: false
-        - class: condition
-          code: "ls"
+          ccode: "hi"
           source: true
           destination: false
       hidden_operands:
@@ -1238,7 +1215,30 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "ge"
+          ccode: "ls"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "ge"
           source: true
           destination: false
       hidden_operands:
@@ -1261,7 +1261,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "lt"
+          ccode: "lt"
           source: true
           destination: false
       hidden_operands:
@@ -1284,34 +1284,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "gt"
-          source: true
-          destination: false
-      hidden_operands:
-        - class: flag
-          name: "N"
-          source: true
-          destination: false
-        - class: flag
-          name: "Z"
-          source: true
-          destination: false
-        - class: flag
-          name: "V"
-          source: true
-          destination: false
-    - name: [cinc, cinv, cneg]
-      operands:
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: register
-          prefix: "*"
-          source: true
-          destination: false
-        - class: condition
-          code: "le"
+          ccode: "gt"
           source: true
           destination: false
       hidden_operands:
@@ -1338,7 +1311,34 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "mi"
+          ccode: "le"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "mi"
           source: true
           destination: false
       hidden_operands:
@@ -1357,7 +1357,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "pl"
+          ccode: "pl"
           source: true
           destination: false
       hidden_operands:
@@ -1376,7 +1376,7 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "vs"
+          ccode: "vs"
           source: true
           destination: false
       hidden_operands:
@@ -1395,10 +1395,41 @@ instruction_forms:
           source: true
           destination: false
         - class: condition
-          code: "vc"
+          ccode: "vc"
           source: true
           destination: false
       hidden_operands:
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "AL"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
         - class: flag
           name: "V"
           source: true
@@ -1410,7 +1441,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "eq"
+          ccode: "eq"
           source: true
           destination: false
       hidden_operands:
@@ -1425,7 +1456,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "ne"
+          ccode: "ne"
           source: true
           destination: false
       hidden_operands:
@@ -1440,7 +1471,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "cs"
+          ccode: "cs"
           source: true
           destination: false
       hidden_operands:
@@ -1455,7 +1486,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "hs"
+          ccode: "hs"
           source: true
           destination: false
       hidden_operands:
@@ -1470,7 +1501,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "cc"
+          ccode: "cc"
           source: true
           destination: false
       hidden_operands:
@@ -1485,7 +1516,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "lo"
+          ccode: "lo"
           source: true
           destination: false
       hidden_operands:
@@ -1500,26 +1531,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "hi"
-          source: true
-          destination: false
-      hidden_operands:
-        - class: flag
-          name: "Z"
-          source: true
-          destination: false
-        - class: flag
-          name: "C"
-          source: true
-          destination: false
-    - name: [cset, csetm]
-      operands:
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: condition
-          code: "ls"
+          ccode: "hi"
           source: true
           destination: false
       hidden_operands:
@@ -1538,7 +1550,26 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "ge"
+          ccode: "ls"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          ccode: "ge"
           source: true
           destination: false
       hidden_operands:
@@ -1557,7 +1588,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "lt"
+          ccode: "lt"
           source: true
           destination: false
       hidden_operands:
@@ -1576,30 +1607,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "gt"
-          source: true
-          destination: false
-      hidden_operands:
-        - class: flag
-          name: "N"
-          source: true
-          destination: false
-        - class: flag
-          name: "Z"
-          source: true
-          destination: false
-        - class: flag
-          name: "V"
-          source: true
-          destination: false
-    - name: [cset, csetm]
-      operands:
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: condition
-          code: "le"
+          ccode: "gt"
           source: true
           destination: false
       hidden_operands:
@@ -1622,7 +1630,30 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "mi"
+          ccode: "le"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          ccode: "mi"
           source: true
           destination: false
       hidden_operands:
@@ -1637,7 +1668,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "pl"
+          ccode: "pl"
           source: true
           destination: false
       hidden_operands:
@@ -1652,7 +1683,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "vs"
+          ccode: "vs"
           source: true
           destination: false
       hidden_operands:
@@ -1667,7 +1698,7 @@ instruction_forms:
           source: false
           destination: true
         - class: condition
-          code: "vc"
+          ccode: "vc"
           source: true
           destination: false
       hidden_operands:
@@ -1675,8 +1706,33 @@ instruction_forms:
           name: "V"
           source: true
           destination: false
-
-
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          ccode: "AL"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
     - name: [csel, csinc, csinv, csneg]
       operands:
         - class: register
@@ -1685,14 +1741,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "eq"
+          ccode: "eq"
           source: true
           destination: false
       hidden_operands:
@@ -1708,14 +1764,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "ne"
+          ccode: "ne"
           source: true
           destination: false
       hidden_operands:
@@ -1731,14 +1787,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "cs"
+          ccode: "cs"
           source: true
           destination: false
       hidden_operands:
@@ -1754,14 +1810,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "hs"
+          ccode: "hs"
           source: true
           destination: false
       hidden_operands:
@@ -1777,14 +1833,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "cc"
+          ccode: "cc"
           source: true
           destination: false
       hidden_operands:
@@ -1800,14 +1856,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "lo"
+          ccode: "lo"
           source: true
           destination: false
       hidden_operands:
@@ -1823,41 +1879,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "hi"
-          source: true
-          destination: false
-      hidden_operands:
-        - class: flag
-          name: "Z"
-          source: true
-          destination: false
-        - class: flag
-          name: "C"
-          source: true
-          destination: false
-    - name: [csel, csinc, csinv, csneg]
-      operands:
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: condition
-          code: "ls"
+          ccode: "hi"
           source: true
           destination: false
       hidden_operands:
@@ -1877,14 +1906,41 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "ls"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
         - class: register
           prefix: "*"
           source: false
           destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
         - class: condition
-          code: "ge"
+          ccode: "ge"
           source: true
           destination: false
       hidden_operands:
@@ -1904,14 +1960,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "lt"
+          ccode: "lt"
           source: true
           destination: false
       hidden_operands:
@@ -1931,45 +1987,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "gt"
-          source: true
-          destination: false
-      hidden_operands:
-        - class: flag
-          name: "N"
-          source: true
-          destination: false
-        - class: flag
-          name: "Z"
-          source: true
-          destination: false
-        - class: flag
-          name: "V"
-          source: true
-          destination: false
-    - name: [csel, csinc, csinv, csneg]
-      operands:
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: register
-          prefix: "*"
-          source: false
-          destination: true
-        - class: condition
-          code: "le"
+          ccode: "gt"
           source: true
           destination: false
       hidden_operands:
@@ -1993,14 +2018,45 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "le"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
         - class: register
           prefix: "*"
           source: false
           destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
         - class: condition
-          code: "mi"
+          ccode: "mi"
           source: true
           destination: false
       hidden_operands:
@@ -2016,14 +2072,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "pl"
+          ccode: "pl"
           source: true
           destination: false
       hidden_operands:
@@ -2039,14 +2095,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "vs"
+          ccode: "vs"
           source: true
           destination: false
       hidden_operands:
@@ -2062,14 +2118,14 @@ instruction_forms:
           destination: true
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: register
           prefix: "*"
-          source: false
-          destination: true
+          source: true
+          destination: false
         - class: condition
-          code: "vc"
+          ccode: "vc"
           source: true
           destination: false
       hidden_operands:
@@ -2077,3 +2133,1228 @@ instruction_forms:
           name: "V"
           source: true
           destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "AL"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "EQ"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "NE"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "CS"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "HS"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "CC"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "LO"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "MI"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "PL"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "VS"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "VC"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "HI"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "LS"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "GE"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "LT"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "GT"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "LE"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "AL"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "EQ"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "NE"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "CS"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "HS"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "CC"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "LO"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "MI"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "PL"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "VS"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "VC"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "HI"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "LS"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "GE"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "LT"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "GT"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "LE"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true
+    - name: [ccmn, ccmp]
+      operands:
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: immediate
+          imd: "int"
+          source: true
+          destination: false
+        - class: condition
+          ccode: "AL"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: true
+        - class: flag
+          name: "C"
+          source: true
+          destination: true
+        - class: flag
+          name: "N"
+          source: true
+          destination: true
+        - class: flag
+          name: "V"
+          source: true
+          destination: true

--- a/osaca/data/isa/aarch64.yml
+++ b/osaca/data/isa/aarch64.yml
@@ -5,7 +5,7 @@ isa: "AArch64"
 #   mnemonic op1 ... opN
 # means that op1 is the only destination operand and op2 to op(N) are source operands.
 instruction_forms:
-    - name: [add, adds]
+    - name: add
       operands:
       - class: register
         prefix: x
@@ -20,7 +20,135 @@ instruction_forms:
         source: true
         destination: false
       operation: "op1['value'] = op2['value'] + op3['value']; op1['name'] = op2['name']"
-    - name: [sub, subs]
+    - name: adds
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+      operation: "op1['value'] = op2['value'] + op3['value']; op1['name'] = op2['name']"
+    - name: adds
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      - class: immediate
+        imd: 'int'
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+      operation: "op1['value'] = op2['value'] + op3['value']; op1['name'] = op2['name']"
+    - name: adds
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+      operation: "op1['value'] = op2['value'] + op3['value']; op1['name'] = op2['name']"
+    - name: adds
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      - class: immediate
+        imd: 'int'
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+      operation: "op1['value'] = op2['value'] + op3['value']; op1['name'] = op2['name']"
+    - name: sub
       operands:
       - class: register
         prefix: x
@@ -35,10 +163,631 @@ instruction_forms:
         source: true
         destination: false
       operation: "op1['value'] = op2['value'] - op3['value']; op1['name'] = op2['name']"
-    - name: [b, bcc, bcs, b.ne, b.any, b.none, b.lt, b.eq, b.hs, b.gt, bne, beq]
+    - name: subs
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+      operation: "op1['value'] = op2['value'] - op3['value']; op1['name'] = op2['name']"
+    - name: subs
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      - class: immediate
+        imd: 'int'
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+      operation: "op1['value'] = op2['value'] - op3['value']; op1['name'] = op2['name']"
+    - name: subs
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+      operation: "op1['value'] = op2['value'] - op3['value']; op1['name'] = op2['name']"
+    - name: subs
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      - class: immediate
+        imd: 'int'
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+      operation: "op1['value'] = op2['value'] - op3['value']; op1['name'] = op2['name']"
+    - name: [adcs, sbcs]
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: true
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: [adcs, sbcs]
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: true
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: negs
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: negs
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: ngcs
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: true
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: ngcs
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: true
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: [ands, bics]
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: [ands, bics]
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      - class: immediate
+        imd: 'int'
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: [ands, bics]
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: [ands, bics]
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      - class: immediate
+        imd: 'int'
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: tst
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: register
+        prefix: x
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: tst
+      operands:
+      - class: register
+        prefix: x
+        source: false
+        destination: true
+      - class: immediate
+        imd: 'int'
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: tst
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: register
+        prefix: w
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: true
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: tst
+      operands:
+      - class: register
+        prefix: w
+        source: false
+        destination: true
+      - class: immediate
+        imd: 'int'
+        source: true
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: false
+        destination: true
+      - class: flag
+        name: "Z"
+        source: false
+        destination: true
+      - class: flag
+        name: "C"
+        source: false
+        destination: true
+      - class: flag
+        name: "V"
+        source: false
+        destination: true
+    - name: [b, b.any, b.none]
       operands:
       - class: identifier
         source: false
+        destination: false
+    # - name: [bcc, bcs, b.ne, b.any, b.none, b.lt, b.eq, b.hs, b.gt, bne, beq]
+    #   operands:
+    #   - class: identifier
+    #     source: false
+    #     destination: false
+    - name: [beq, b.eq, bne, b.ne]
+      operands:
+      - class: identifier
+        source: false
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "Z"
+        source: true
+        destination: false
+    - name: [bcs, b.cs, bhs, b.hs, bcc, b.cc, blo, b.lo]
+      operands:
+      - class: identifier
+        source: false
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "C"
+        source: true
+        destination: false
+    - name: [bhi, b.hi, bls, b.ls]
+      operands:
+      - class: identifier
+        source: false
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "Z"
+        source: true
+        destination: false
+      - class: flag
+        name: "C"
+        source: true
+        destination: false
+    - name: [bge, b.ge, blt, b.lt]
+      operands:
+      - class: identifier
+        source: false
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: true
+        destination: false
+      - class: flag
+        name: "V"
+        source: true
+        destination: false
+    - name: [bgt, b.gt, ble, b.le]
+      operands:
+      - class: identifier
+        source: false
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: true
+        destination: false
+      - class: flag
+        name: "Z"
+        source: true
+        destination: false
+      - class: flag
+        name: "V"
+        source: true
+        destination: false
+    - name: [bmi, b.mi, bpl, b.pl]
+      operands:
+      - class: identifier
+        source: false
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "N"
+        source: true
+        destination: false
+    - name: [bvs, b.vs, bvc, b.vc]
+      operands:
+      - class: identifier
+        source: false
+        destination: false
+      hidden_operands:
+      - class: flag
+        name: "V"
+        source: true
         destination: false
     - name: [incb, incd]
       operands:
@@ -190,6 +939,23 @@ instruction_forms:
           prefix: "*"
           source: true
           destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
     - name: cmp
       operands:
         - class: register
@@ -200,6 +966,23 @@ instruction_forms:
           imd: "int"
           source: true
           destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
     - name: cmn
       operands:
         - class: register
@@ -210,6 +993,23 @@ instruction_forms:
           prefix: "*"
           source: true
           destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
     - name: cmn
       operands:
         - class: register
@@ -220,6 +1020,23 @@ instruction_forms:
           imd: "int"
           source: true
           destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: false
+          destination: true
+        - class: flag
+          name: "Z"
+          source: false
+          destination: true
+        - class: flag
+          name: "C"
+          source: false
+          destination: true
+        - class: flag
+          name: "V"
+          source: false
+          destination: true
     - name: fcmp
       operands:
         - class: register
@@ -248,5 +1065,1015 @@ instruction_forms:
           destination: false
         - class: immediate
           imd: float
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "eq"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "ne"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "cs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "hs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "cc"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "lo"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "hi"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "ls"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "ge"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "lt"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "gt"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "le"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "mi"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "pl"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "vs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cinc, cinv, cneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: true
+          destination: false
+        - class: condition
+          code: "vc"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "eq"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "ne"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "cs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "hs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "cc"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "lo"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "hi"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "ls"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "ge"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "lt"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "gt"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "le"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "mi"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "pl"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "vs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [cset, csetm]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "vc"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+
+
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "eq"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "ne"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "cs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "hs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "cc"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "lo"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "hi"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "ls"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "C"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "ge"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "lt"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "gt"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "le"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+        - class: flag
+          name: "Z"
+          source: true
+          destination: false
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "mi"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "pl"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "N"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "vs"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "V"
+          source: true
+          destination: false
+    - name: [csel, csinc, csinv, csneg]
+      operands:
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: register
+          prefix: "*"
+          source: false
+          destination: true
+        - class: condition
+          code: "vc"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: flag
+          name: "V"
           source: true
           destination: false

--- a/osaca/frontend.py
+++ b/osaca/frontend.py
@@ -144,9 +144,9 @@ class Frontend(object):
             + "-----------------------------------------\n"
         )
         # TODO find a way to overcome padding for different tab-lengths
-        for dep in dep_dict:
+        for dep in sorted(dep_dict.keys()):
             s += "{:4d} {} {:4.1f} {} {:36}{} {}\n".format(
-                dep,
+                int(dep.split("-")[0]),
                 separator,
                 dep_dict[dep]["latency"],
                 separator,

--- a/osaca/osaca.py
+++ b/osaca/osaca.py
@@ -171,6 +171,14 @@ def create_parser(parser=None):
         " Set to -1 for no timeout.",
     )
     parser.add_argument(
+        "--consider-flag-deps",
+        "-f",
+        dest="consider_flag_deps",
+        action="store_true",
+        default=False,
+        help="Consider flag dependencies (carry, zero, ...)",
+    )
+    parser.add_argument(
         "--verbose", "-v", action="count", default=0, help="Increases verbosity level."
     )
     parser.add_argument(
@@ -333,7 +341,9 @@ def inspect(args, output_file=sys.stdout):
         semantics.assign_optimal_throughput(kernel)
 
     # Create DiGrahps
-    kernel_graph = KernelDG(kernel, parser, machine_model, semantics, args.lcd_timeout)
+    kernel_graph = KernelDG(
+        kernel, parser, machine_model, semantics, args.lcd_timeout, args.consider_flag_deps
+    )
     if args.dotpath is not None:
         kernel_graph.export_graph(args.dotpath if args.dotpath != "." else None)
     # Print analysis

--- a/osaca/parser/parser_AArch64.py
+++ b/osaca/parser/parser_AArch64.py
@@ -198,7 +198,7 @@ class ParserAArch64(BaseParser):
         ).setResultsName("prfop")
         # Condition codes, based on http://tiny.cc/armcc
         condition = (
-            pp.CaselessLiteral("EQ")    # z set
+            pp.CaselessLiteral("EQ")  # z set
             ^ pp.CaselessLiteral("NE")  # z clear
             ^ pp.CaselessLiteral("CS")  # c set
             ^ pp.CaselessLiteral("HS")  # c set

--- a/osaca/parser/parser_AArch64.py
+++ b/osaca/parser/parser_AArch64.py
@@ -196,11 +196,34 @@ class ParserAArch64(BaseParser):
                 "policy"
             )
         ).setResultsName("prfop")
+        # Condition codes
+        condition = pp.Group(
+            (
+                pp.CaselessLiteral("EQ")
+                ^ pp.CaselessLiteral("NE")
+                ^ pp.CaselessLiteral("CS")
+                ^ pp.CaselessLiteral("HS")
+                ^ pp.CaselessLiteral("CC")
+                ^ pp.CaselessLiteral("LO")
+                ^ pp.CaselessLiteral("HI")
+                ^ pp.CaselessLiteral("LS")
+                ^ pp.CaselessLiteral("GE")
+                ^ pp.CaselessLiteral("LT")
+                ^ pp.CaselessLiteral("GT")
+                ^ pp.CaselessLiteral("LE")
+                ^ pp.CaselessLiteral("MI")
+                ^ pp.CaselessLiteral("PL")
+                ^ pp.CaselessLiteral("VS")
+                ^ pp.CaselessLiteral("VC")
+            ).setResultsName("code")
+        ).setResultsName("condition")
         # Combine to instruction form
         operand_first = pp.Group(
             register ^ (prefetch_op | immediate) ^ memory ^ arith_immediate ^ identifier
         )
-        operand_rest = pp.Group((register ^ immediate ^ memory ^ arith_immediate) | identifier)
+        operand_rest = pp.Group(
+            (register ^ condition ^ immediate ^ memory ^ arith_immediate) | identifier
+        )
         self.instruction_parser = (
             mnemonic
             + pp.Optional(operand_first.setResultsName("operand1"))
@@ -561,7 +584,7 @@ class ParserAArch64(BaseParser):
         """Check if ``flag_a`` is dependent on ``flag_b``"""
         # we assume flags are independent of each other, e.g., CF can be read while ZF gets written
         # TODO validate this assumption
-        if flag_a.name == flag_b.name:
+        if flag_a["name"] == flag_b["name"]:
             return True
         return False
 

--- a/osaca/parser/parser_AArch64.py
+++ b/osaca/parser/parser_AArch64.py
@@ -196,27 +196,27 @@ class ParserAArch64(BaseParser):
                 "policy"
             )
         ).setResultsName("prfop")
-        # Condition codes
-        condition = pp.Group(
-            (
-                pp.CaselessLiteral("EQ")
-                ^ pp.CaselessLiteral("NE")
-                ^ pp.CaselessLiteral("CS")
-                ^ pp.CaselessLiteral("HS")
-                ^ pp.CaselessLiteral("CC")
-                ^ pp.CaselessLiteral("LO")
-                ^ pp.CaselessLiteral("HI")
-                ^ pp.CaselessLiteral("LS")
-                ^ pp.CaselessLiteral("GE")
-                ^ pp.CaselessLiteral("LT")
-                ^ pp.CaselessLiteral("GT")
-                ^ pp.CaselessLiteral("LE")
-                ^ pp.CaselessLiteral("MI")
-                ^ pp.CaselessLiteral("PL")
-                ^ pp.CaselessLiteral("VS")
-                ^ pp.CaselessLiteral("VC")
-            ).setResultsName("code")
+        # Condition codes, based on http://tiny.cc/armcc
+        condition = (
+            pp.CaselessLiteral("EQ")    # z set
+            ^ pp.CaselessLiteral("NE")  # z clear
+            ^ pp.CaselessLiteral("CS")  # c set
+            ^ pp.CaselessLiteral("HS")  # c set
+            ^ pp.CaselessLiteral("CC")  # c clear
+            ^ pp.CaselessLiteral("LO")  # c clear
+            ^ pp.CaselessLiteral("MI")  # n set
+            ^ pp.CaselessLiteral("PL")  # n clear
+            ^ pp.CaselessLiteral("VS")  # v set
+            ^ pp.CaselessLiteral("VC")  # v clear
+            ^ pp.CaselessLiteral("HI")  # c set and z clear
+            ^ pp.CaselessLiteral("LS")  # c clear or z set
+            ^ pp.CaselessLiteral("GE")  # n and v the same
+            ^ pp.CaselessLiteral("LT")  # n and v different
+            ^ pp.CaselessLiteral("GT")  # z clear, and n and v the same
+            ^ pp.CaselessLiteral("LE")  # z set, or n and v different
+            ^ pp.CaselessLiteral("AL")  # any
         ).setResultsName("condition")
+        self.condition = condition
         # Combine to instruction form
         operand_first = pp.Group(
             register ^ (prefetch_op | immediate) ^ memory ^ arith_immediate ^ identifier

--- a/osaca/semantics/hw_model.py
+++ b/osaca/semantics/hw_model.py
@@ -581,8 +581,15 @@ class MachineModel(object):
         # prefetch option
         if "prfop" in operand:
             return i_operand["class"] == "prfop"
+        # condition
         if "condition" in operand:
-            return i_operand["class"] == "condition"
+            if i_operand["ccode"] == self.WILDCARD:
+                return True
+            return i_operand["class"] == "condition" and (
+                operand.get("condition", None) == i_operand.get("ccode", None).upper()
+                if isinstance(i_operand.get("ccode", None), str)
+                else i_operand.get("ccode", None)
+            )
         # no match
         return False
 

--- a/osaca/semantics/hw_model.py
+++ b/osaca/semantics/hw_model.py
@@ -581,6 +581,8 @@ class MachineModel(object):
         # prefetch option
         if "prfop" in operand:
             return i_operand["class"] == "prfop"
+        if "condition" in operand:
+            return i_operand["class"] == "condition"
         # no match
         return False
 

--- a/osaca/semantics/isa_semantics.py
+++ b/osaca/semantics/isa_semantics.py
@@ -127,7 +127,6 @@ class ISASemantics(object):
                             }
                         )
                     )
-
         # store operand list in dict and reassign operand key/value pair
         instruction_form["semantic_operands"] = AttrDict.convert_dict(op_dict)
         # assign LD/ST flags

--- a/tests/test_files/kernel_aarch64_deps.s
+++ b/tests/test_files/kernel_aarch64_deps.s
@@ -1,0 +1,14 @@
+// OSACA-BEGIN
+.LBB0_32:
+    ldp q4, q5, [x9, #-32]
+    ldp q6, q7, [x9], #64
+    add x9, x9, x9
+    add x10, x9, #64           // =64
+    fmul    v4.2d, v4.2d, v6.2d
+    fmul    v5.2d, v4.2d, v7.2d
+    adds x10, x10, x10
+    csel, x9, x1, x9, eq
+    stp q14, q15, [x9, #-32]!
+    stp q14, q15, [x9], #64
+    b.ne    .LBB0_32
+// OSACA-END

--- a/tests/test_parser_AArch64.py
+++ b/tests/test_parser_AArch64.py
@@ -313,7 +313,7 @@ class TestParserAArch64(unittest.TestCase):
                 {"register": {"prefix": "x", "name": "11"}},
                 {"immediate": {"value": 1, "type": "int"}},
                 {"immediate": {"value": 3, "type": "int"}},
-                {"condition": "EQ"}
+                {"condition": "EQ"},
             ],
             "directive": None,
             "comment": None,

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -43,6 +43,8 @@ class TestSemanticTools(unittest.TestCase):
             cls.code_AArch64 = f.read()
         with open(cls._find_file("kernel_aarch64_sve.s")) as f:
             cls.code_AArch64_SVE = f.read()
+        with open(cls._find_file("kernel_aarch64_deps.s")) as f:
+            cls.code_AArch64_deps = f.read()
         cls.kernel_x86 = reduce_to_section(cls.parser_x86.parse_file(cls.code_x86), "x86")
         cls.kernel_x86_memdep = reduce_to_section(
             cls.parser_x86.parse_file(cls.code_x86_memdep), "x86"
@@ -58,6 +60,9 @@ class TestSemanticTools(unittest.TestCase):
         )
         cls.kernel_aarch64_SVE = reduce_to_section(
             cls.parser_AArch64.parse_file(cls.code_AArch64_SVE), "aarch64"
+        )
+        cls.kernel_aarch64_deps = reduce_to_section(
+            cls.parser_AArch64.parse_file(cls.code_AArch64_deps), "aarch64"
         )
 
         # set up machine models
@@ -104,6 +109,9 @@ class TestSemanticTools(unittest.TestCase):
         for i in range(len(cls.kernel_aarch64_SVE)):
             cls.semantics_a64fx.assign_src_dst(cls.kernel_aarch64_SVE[i])
             cls.semantics_a64fx.assign_tp_lt(cls.kernel_aarch64_SVE[i])
+        for i in range(len(cls.kernel_aarch64_deps)):
+            cls.semantics_a64fx.assign_src_dst(cls.kernel_aarch64_deps[i])
+            cls.semantics_a64fx.assign_tp_lt(cls.kernel_aarch64_deps[i])
 
     ###########
     # Tests
@@ -365,7 +373,7 @@ class TestSemanticTools(unittest.TestCase):
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=3)), {7, 8})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=4)), {9, 10})
-        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {7, 8})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {6, 7, 8})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=6)), {9, 10})
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=7)), 13)
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=8)), 14)
@@ -434,40 +442,76 @@ class TestSemanticTools(unittest.TestCase):
             self.semantics_tx2,
         )
         lc_deps = dg.get_loopcarried_dependencies()
-        self.assertEqual(len(lc_deps), 2)
+        self.assertEqual(len(lc_deps), 4)
         # based on line 6
-        self.assertEqual(lc_deps[6]["latency"], 28.0)
+        dep_path = "6-10-11-12-13-14"
+        self.assertEqual(lc_deps[dep_path]["latency"], 29.0)
         self.assertEqual(
-            [(iform.line_number, lat) for iform, lat in lc_deps[6]["dependencies"]],
-            [(6, 4.0), (10, 6.0), (11, 6.0), (12, 6.0), (13, 6.0), (14, 0)],
+            [
+                (iform.line_number, lat)
+                for iform, lat in lc_deps[dep_path]["dependencies"]
+            ],
+            [(6, 4.0), (10, 6.0), (11, 6.0), (12, 6.0), (13, 6.0), (14, 1.0)],
+        )
+        dg = KernelDG(
+            self.kernel_aarch64_deps,
+            self.parser_AArch64,
+            self.machine_model_a64fx,
+            self.semantics_a64fx,
+            flag_dependencies=True,
+        )
+        lc_deps = dg.get_loopcarried_dependencies()
+        self.assertEqual(len(lc_deps), 2)
+        # based on line 4
+        dep_path = "4-5-6-9-10-11-12"
+        self.assertEqual(lc_deps[dep_path]["latency"], 7.0)
+        self.assertEqual(
+            [(iform.line_number, lat) for iform, lat in lc_deps[dep_path]["dependencies"]],
+            [(4, 1.0), (5, 1.0), (6, 1.0), (9, 1.0), (10, 1.0), (11, 1.0), (12, 1.0)],
+        )
+        dg = KernelDG(
+            self.kernel_aarch64_deps,
+            self.parser_AArch64,
+            self.machine_model_a64fx,
+            self.semantics_a64fx,
+            flag_dependencies=False,
+        )
+        lc_deps = dg.get_loopcarried_dependencies()
+        self.assertEqual(len(lc_deps), 1)
+        # based on line 4
+        dep_path = "4-5-10-11-12"
+        self.assertEqual(lc_deps[dep_path]["latency"], 5.0)
+        self.assertEqual(
+            [(iform.line_number, lat) for iform, lat in lc_deps[dep_path]["dependencies"]],
+            [(4, 1.0), (5, 1.0), (10, 1.0), (11, 1.0), (12, 1.0)],
         )
 
     def test_loop_carried_dependency_x86(self):
-        lcd_id = 8
-        lcd_id2 = 5
+        lcd_id = "8"
+        lcd_id2 = "5"
         dg = KernelDG(self.kernel_x86, self.parser_x86, self.machine_model_csx, self.semantics_csx)
         lc_deps = dg.get_loopcarried_dependencies()
         self.assertEqual(len(lc_deps), 2)
         # ID 8
         self.assertEqual(
-            lc_deps[lcd_id]["root"], dg.dg.nodes(data=True)[lcd_id]["instruction_form"]
+            lc_deps[lcd_id]["root"], dg.dg.nodes(data=True)[int(lcd_id)]["instruction_form"]
         )
         self.assertEqual(len(lc_deps[lcd_id]["dependencies"]), 1)
         self.assertEqual(
             lc_deps[lcd_id]["dependencies"][0][0],
-            dg.dg.nodes(data=True)[lcd_id]["instruction_form"],
+            dg.dg.nodes(data=True)[int(lcd_id)]["instruction_form"],
         )
         # w/  flag dependencies: ID 9 w/ len=2
         # w/o flag dependencies: ID 5 w/ len=1
         # TODO discuss
         self.assertEqual(
             lc_deps[lcd_id2]["root"],
-            dg.dg.nodes(data=True)[lcd_id2]["instruction_form"],
+            dg.dg.nodes(data=True)[int(lcd_id2)]["instruction_form"],
         )
         self.assertEqual(len(lc_deps[lcd_id2]["dependencies"]), 1)
         self.assertEqual(
             lc_deps[lcd_id2]["dependencies"][0][0],
-            dg.dg.nodes(data=True)[lcd_id2]["instruction_form"],
+            dg.dg.nodes(data=True)[int(lcd_id2)]["instruction_form"],
         )
 
     def test_timeout_during_loop_carried_dependency(self):

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -451,10 +451,7 @@ class TestSemanticTools(unittest.TestCase):
         dep_path = "6-10-11-12-13-14"
         self.assertEqual(lc_deps[dep_path]["latency"], 29.0)
         self.assertEqual(
-            [
-                (iform.line_number, lat)
-                for iform, lat in lc_deps[dep_path]["dependencies"]
-            ],
+            [(iform.line_number, lat) for iform, lat in lc_deps[dep_path]["dependencies"]],
             [(6, 4.0), (10, 6.0), (11, 6.0), (12, 6.0), (13, 6.0), (14, 1.0)],
         )
         dg = KernelDG(


### PR DESCRIPTION
This PR implements support for flags (NZCV) and conditional operations on AArch64.

All integer instructions that update or read from the flags were added/updated in `data/isa/aarch64.yml`. A small change in the parsing grammar was required, due to condition code arguments on conditional instructions such as `csel x0, x1, x2, eq`. 

I will be glad to assist in getting this merged. Please let me know anything that is needed from my end to make sure this is merged.