### PR TITLE
Add IMUL instruction for Zen 3 architectures

### DIFF
--- a/osaca/data/zen3.yml
+++ b/osaca/data/zen3.yml
@@ -5515,3 +5515,13 @@ instruction_forms:
   latency: 3
   port_pressure: [[1, '7']]
   throughput: 1.0
+- name: imul # uops.info
+  operands:
+  - class: register
+    name: gpr
+  - class: register
+    name: gpr
+  latency: 3
+  port_pressure: [[1, '7']]
+  throughput: 1.0
+  uops: 1


### PR DESCRIPTION
This commit adds data on the `IMUL (r, r)` instruction on the AMD Zen 3 microarchitecture, as provided by uops.info.