### PR TITLE
Support for arithmetic shift and comparison instructions for x86

### DIFF
--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -4415,7 +4415,7 @@ instruction_forms:
           name: "xmm"
           source: true
           destination: true
-    - name: [shl, shr, shlq, shrq]
+    - name: [sal, sar, salq, sarq, shl, shr, shlq, shrq]
       operands:
         - class: "immediate"
           imd: "int"

--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -2621,7 +2621,7 @@ instruction_forms:
           name: "ZF"
           source: true
           destination: true
-    - name: comisd
+    - name: ["comisd", "ucomisd"]
       operands:
         - class: "register"
           name: "xmm"
@@ -2656,7 +2656,7 @@ instruction_forms:
           name: "PF"
           source: false
           destination: true
-    - name: comisd
+    - name: ["comisd", "ucomisd"]
       operands:
         - class: "register"
           name: "xmm"

--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -2621,6 +2621,79 @@ instruction_forms:
           name: "ZF"
           source: true
           destination: true
+    - name: comisd
+      operands:
+        - class: "register"
+          name: "xmm"
+          source: true
+          destination: false
+        - class: "register"
+          name: "xmm"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: "flag"
+          name: "CF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "OF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "SF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "ZF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "AF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "PF"
+          source: false
+          destination: true
+    - name: comisd
+      operands:
+        - class: "register"
+          name: "xmm"
+          source: true
+          destination: false
+        - class: "memory"
+          base: "*"
+          offset: "*"
+          index: "*"
+          scale: "*"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: "flag"
+          name: "CF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "OF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "SF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "ZF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "AF"
+          source: false
+          destination: true
+        - class: "flag"
+          name: "PF"
+          source: false
+          destination: true
     - name: dec
       operands:
         - class: "register"
@@ -3613,7 +3686,7 @@ instruction_forms:
         - class: "register"
           name: "gpr"
           source: true
-          destination: true 
+          destination: true
     - name: sbb
       operands:
         - class: "register"

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -849,6 +849,9 @@ class TestSemanticTools(unittest.TestCase):
         instr_form_r_ymm = self.parser_x86_intel.parse_line("vmovapd ymm0, ymm1")
         self.semantics_csx_intel.normalize_instruction_form(instr_form_r_ymm)
         self.semantics_csx_intel.assign_src_dst(instr_form_r_ymm)
+        instr_form_rw_sar = self.parser_x86_intel.parse_line("sar rcx, 43")
+        self.semantics_csx_intel.normalize_instruction_form(instr_form_rw_sar)
+        self.semantics_csx_intel.assign_src_dst(instr_form_rw_sar)
         self.assertTrue(dag.is_read(reg_rcx, instr_form_r_c))
         self.assertFalse(dag.is_read(reg_rcx, instr_form_non_r_c))
         self.assertFalse(dag.is_read(reg_rcx, instr_form_w_c))
@@ -860,6 +863,8 @@ class TestSemanticTools(unittest.TestCase):
         self.assertTrue(dag.is_written(reg_ymm1, instr_form_rw_ymm_1))
         self.assertTrue(dag.is_written(reg_ymm1, instr_form_rw_ymm_2))
         self.assertFalse(dag.is_written(reg_ymm1, instr_form_r_ymm))
+        self.assertTrue(dag.is_read(reg_rcx, instr_form_rw_sar))
+        self.assertTrue(dag.is_written(reg_rcx, instr_form_rw_sar))
 
     def test_is_read_is_written_AArch64(self):
         # independent form HW model


### PR DESCRIPTION
1. Add `comisd` and `ucomisd` for register-register and register-memory operations, together with their effect on the flags.
2. Add arithmetic shifts `sal`, `sar`, `salq`, and `sarq`, similar to their logical equivalents.
3. Add a test that sources and destinations are correctly set for `sar` (Intel syntax).