### PR TITLE
Improvements to graph layout and colouring

### DIFF
--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -551,7 +551,7 @@ class KernelDG(nx.DiGraph):
                 if n in lcd_line_numbers[dep]:
                     if "style" not in graph.nodes[n]:
                         graph.nodes[n]["style"] = "filled"
-                    else:
+                    elif ",filled" not in graph.nodes[n]["style"]:
                         graph.nodes[n]["style"] += ",filled"
                     graph.nodes[n]["fillcolor"] = 2 + col % 11
 

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -528,8 +528,8 @@ class KernelDG(nx.DiGraph):
         for dep in lcd_line_numbers:
             min_line_number = min(lcd_line_numbers[dep])
             max_line_number = max(lcd_line_numbers[dep])
-            graph.add_edge(max_line_number, min_line_number)
-            graph.edges[max_line_number, min_line_number]["latency"] = [
+            graph.add_edge(min_line_number, max_line_number, dir="back")
+            graph.edges[min_line_number, max_line_number]["latency"] = [
                 lat for x, lat in lcd[dep]["dependencies"] if x.line_number == max_line_number
             ]
 

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -599,7 +599,10 @@ class KernelDG(nx.DiGraph):
             else:
                 graph.nodes[n]["style"] += ",filled"
             graph.nodes[n]["fillcolor"] = color
-            if (max_color >= 4 and color == 1) or (max_color >= 10 and color in (1, 2, max_color)):
+            if (
+                (max_color >= 4 and color in (1, max_color)) or
+                (max_color >= 10 and color in (1, 2, max_color - 1 , max_color))
+            ):
                 graph.nodes[n]["fontcolor"] = "white"
         for (u, v), color in edge_colors.items():
             # The backward edge of the cycle is represented as the corresponding forward

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -521,8 +521,8 @@ class KernelDG(nx.DiGraph):
         for dep in lcd:
             lcd_line_numbers[dep] = [x.line_number for x, lat in lcd[dep]["dependencies"]]
         # add color scheme
-        graph.graph["node"] = {"colorscheme": "accent8"}
-        graph.graph["edge"] = {"colorscheme": "accent8"}
+        graph.graph["node"] = {"colorscheme": "set312"}
+        graph.graph["edge"] = {"colorscheme": "set312"}
 
         # create LCD edges
         for dep in lcd_line_numbers:

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -553,7 +553,7 @@ class KernelDG(nx.DiGraph):
                         graph.nodes[n]["style"] = "filled"
                     else:
                         graph.nodes[n]["style"] += ",filled"
-                    graph.nodes[n]["fillcolor"] = 2 + col
+                    graph.nodes[n]["fillcolor"] = 2 + col % 11
 
         # color edges
         for e in graph.edges:


### PR DESCRIPTION
* On sufficiently complex code, the graph generator would run out of colours, causing dot to produce a black graph, see Figure 1.
* The LCD backward edges caused dot to reorder the instructions arbitrarily, so that the last instruction in the LCD path ended up in the middle. The last instruction of the LCD path is marked with 👉 in Figures 1–3.
* The colours were applied in the order in which the paths were found, so that the most critical loop-carried path would not usually be legible in the end: it would have many colours, see Figure 3. Instead, this PR colours vertices and edges based on the latency of the longest LCD cycle going through them, as shown in Figure 4.

The figures are based on code generated by MSVC for [an implementation of a cube root](https://github.com/mockingbirdnest/Principia/blob/2f768323c7952830c17d648ec181d5037722db95/numerics/cbrt.cpp#L249-L332). They were generated at various commits in this PR, with the changes from #115 also merged in.

| Figure 1 (Current) | Figure 2 (Don’t run out of colours) |
|---|---|
| ![a](https://github.com/user-attachments/assets/91986916-c9e2-42e1-abb3-810f4fd1d6ed) | ![b](https://github.com/user-attachments/assets/e819b283-d872-4823-aeee-d967f4e8db8a) |

| Figure 3 (Mark backward edges as backward so the graph is ordered like the code) | Figure 4 (All changes in this PR) |
|---|---|
| ![c](https://github.com/user-attachments/assets/31f3e7fe-9764-4783-b579-6fe2cb815d3f) | ![d](https://github.com/user-attachments/assets/1d9fa480-849c-4f24-86f8-3ee9726bfeea) |

