### PR TITLE
Properly track the dependencies of the LOAD phase of instructions

### DIFF
--- a/osaca/frontend.py
+++ b/osaca/frontend.py
@@ -80,7 +80,7 @@ class Frontend(object):
         s += lineno_filler + self._get_port_number_line(port_len) + "\n"
         s += separator + "\n"
         for instruction_form in kernel:
-            line = "{:4d} {} {} {}".format(
+            line = "{:4.0f} {} {} {}".format(
                 instruction_form.line_number,
                 self._get_port_pressure(
                     instruction_form.port_pressure, port_len, separator=sep_list
@@ -113,7 +113,7 @@ class Frontend(object):
         s = "\n\nLatency Analysis Report\n-----------------------\n"
         for instruction_form in cp_kernel:
             s += (
-                "{:4d} {} {:4.1f} {}{}{} {}".format(
+                "{:4.0f} {} {:4.1f} {}{}{} {}".format(
                     instruction_form.line_number,
                     separator,
                     instruction_form.latency_cp,
@@ -147,8 +147,8 @@ class Frontend(object):
         )
         # TODO find a way to overcome padding for different tab-lengths
         for dep in sorted(dep_dict.keys()):
-            s += "{:4d} {} {:4.1f} {} {:36}{} {}\n".format(
-                int(dep.split("-")[0]),
+            s += "{:4.0f} {} {:4.1f} {} {:36}{} {}\n".format(
+                float(dep.split("-")[0]),
                 separator,
                 dep_dict[dep]["latency"],
                 separator,
@@ -358,7 +358,7 @@ class Frontend(object):
             line_number = instruction_form.line_number
             used_ports = [list(uops[1]) for uops in instruction_form.port_uops]
             used_ports = list(set([p for uops_ports in used_ports for p in uops_ports]))
-            s += "{:4d} {}{} {} {}\n".format(
+            s += "{:4.0f} {}{} {} {}\n".format(
                 line_number,
                 self._get_port_pressure(
                     instruction_form.port_pressure, port_len, used_ports, sep_list

--- a/osaca/frontend.py
+++ b/osaca/frontend.py
@@ -80,7 +80,9 @@ class Frontend(object):
         s += lineno_filler + self._get_port_number_line(port_len) + "\n"
         s += separator + "\n"
         for instruction_form in kernel:
-            line = "{:4.0f} {} {} {}".format(
+            if KernelDG.is_load_line_number(instruction_form.line_number):
+                continue
+            line = "{:4d} {} {} {}".format(
                 instruction_form.line_number,
                 self._get_port_pressure(
                     instruction_form.port_pressure, port_len, separator=sep_list
@@ -112,8 +114,10 @@ class Frontend(object):
         """
         s = "\n\nLatency Analysis Report\n-----------------------\n"
         for instruction_form in cp_kernel:
+            if KernelDG.is_load_line_number(instruction_form.line_number):
+                continue
             s += (
-                "{:4.0f} {} {:4.1f} {}{}{} {}".format(
+                "{:4d} {} {:4.1f} {}{}{} {}".format(
                     instruction_form.line_number,
                     separator,
                     instruction_form.latency_cp,
@@ -147,8 +151,11 @@ class Frontend(object):
         )
         # TODO find a way to overcome padding for different tab-lengths
         for dep in sorted(dep_dict.keys()):
+            dep0 = float(dep.split("-")[0])
+            if KernelDG.is_load_line_number(dep0):
+                continue
             s += "{:4.0f} {} {:4.1f} {} {:36}{} {}\n".format(
-                float(dep.split("-")[0]),
+                dep0,
                 separator,
                 dep_dict[dep]["latency"],
                 separator,
@@ -356,9 +363,11 @@ class Frontend(object):
             if show_cmnts is False and self._is_comment(instruction_form):
                 continue
             line_number = instruction_form.line_number
+            if KernelDG.is_load_line_number(line_number):
+                continue
             used_ports = [list(uops[1]) for uops in instruction_form.port_uops]
             used_ports = list(set([p for uops_ports in used_ports for p in uops_ports]))
-            s += "{:4.0f} {}{} {} {}\n".format(
+            s += "{:4d} {}{} {} {}\n".format(
                 line_number,
                 self._get_port_pressure(
                     instruction_form.port_pressure, port_len, used_ports, sep_list

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -82,9 +82,8 @@ class KernelDG(nx.DiGraph):
         :type flag_dependencies: boolean, optional
         :returns: :class:`~nx.DiGraph` -- directed graph object
         """
-        # 1. go through kernel instruction forms and add them as node attribute
-        # 2. find edges (to dependend further instruction)
-        # 3. get LT value and set as edge weight
+        # Go through kernel instruction forms and add them as nodes of the graph.  Create a LOAD
+        # node for instructions that include a memory reference.
         dg = nx.DiGraph()
         loads = {}
         for i, instruction_form in enumerate(kernel):
@@ -110,11 +109,14 @@ class KernelDG(nx.DiGraph):
                     instruction_form.line_number,
                     latency=instruction_form.latency - instruction_form.latency_wo_load,
                 )
-        #TODO comments
+
+        # 1. find edges (to dependend further instruction)
+        # 2. get LT value and set as edge weight
         for i, instruction_form in enumerate(kernel):
             for dep, dep_flags in self.find_depending(
                 instruction_form, kernel[i + 1 :], flag_dependencies
             ):
+                # print(instruction_form.line_number,"\t",dep.line_number,"\n")
                 edge_weight = (
                     instruction_form.latency
                     if "mem_dep" in dep_flags or instruction_form.latency_wo_load is None

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -56,7 +56,8 @@ class KernelDG(nx.DiGraph):
     @staticmethod
     def get_load_line_number(line_number):
         # The line number of the load must be less than the line number of the instruction.  The
-        # offset is irrelevant, but it must be a machine number to avoid silly rounding issues.
+        # offset is irrelevant, but it must be a machine number with trailing zeroes to avoid silly
+        # rounding issues.
         return line_number - 0.125
 
     @staticmethod

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -112,14 +112,12 @@ class KernelDG(nx.DiGraph):
                 if "p_indexed" in dep_flags and self.model is not None:
                     edge_weight = self.model.get("p_index_latency", 1)
                 if "for_load" in dep_flags and self.model is not None and dep.line_number in loads:
-                    #print("LOADDEP", instruction_form.line_number, loads[dep.line_number])
                     dg.add_edge(
                         instruction_form.line_number,
                         loads[dep.line_number],
                         latency=edge_weight,
                     )
                 else:
-                    #print("DEP", instruction_form.line_number, dep.line_number)
                     dg.add_edge(
                         instruction_form.line_number,
                         dep.line_number,
@@ -405,17 +403,13 @@ class KernelDG(nx.DiGraph):
                 is_read = self.parser.is_flag_dependend_of(register, src) or is_read
             if isinstance(src, MemoryOperand):
                 is_memory_read = False
-                #print("1", is_read)
                 if src.base is not None:
                     is_memory_read = self.parser.is_reg_dependend_of(register, src.base)
-                #print("2", is_read)
                 if src.index is not None and isinstance(src.index, RegisterOperand):
                     is_memory_read = (
                         self.parser.is_reg_dependend_of(register, src.index)
                         or is_memory_read
                     )
-                #print("3", is_read)
-                #print("FORLOAD", register, src)
                 for_load = is_memory_read
                 is_read = is_read or is_memory_read
         # Check also if read in destination memory address
@@ -566,7 +560,6 @@ class KernelDG(nx.DiGraph):
         lcd_line_numbers = {}
         for dep in lcd:
             lcd_line_numbers[dep] = [x.line_number for x, lat in lcd[dep]["dependencies"]]
-        print("LCDLN", lcd_line_numbers)
 
         # create LCD edges
         for dep in lcd_line_numbers:
@@ -579,7 +572,6 @@ class KernelDG(nx.DiGraph):
 
         # add label to edges
         for e in graph.edges:
-            print("EDGE", e)
             graph.edges[e]["label"] = graph.edges[e]["latency"]
 
         # add CP values to graph
@@ -592,8 +584,6 @@ class KernelDG(nx.DiGraph):
                 # graph.nodes[n]['color'] = 1
                 graph.nodes[n]["style"] = "bold"
                 graph.nodes[n]["penwidth"] = 4
-
-        print("CPLN", cp_line_numbers)
 
         # Make critical path edges bold.
         for u, v in zip(cp_line_numbers[:-1], cp_line_numbers[1:]):
@@ -628,7 +618,6 @@ class KernelDG(nx.DiGraph):
                         # Don’t introduce a color just for an edge.
                         if not color:
                             color = colors_used
-                        print("EC", u, v, color)
                         edge_colors[u, v] = color
         max_color = min(11, colors_used)
         colorscheme = f"spectral{max(3, max_color)}"

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -646,8 +646,8 @@ class KernelDG(nx.DiGraph):
                 graph.nodes[n]["style"] += ",filled"
             graph.nodes[n]["fillcolor"] = color
             if (
-                (max_color >= 4 and color in (1, max_color)) or
-                (max_color >= 10 and color in (1, 2, max_color - 1 , max_color))
+                (max_color >= 4 and color in (1, max_color)) 
+                or (max_color >= 10 and color in (1, 2, max_color - 1 , max_color))
             ):
                 graph.nodes[n]["fontcolor"] = "white"
         for (u, v), color in edge_colors.items():

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -646,7 +646,7 @@ class KernelDG(nx.DiGraph):
                 graph.nodes[n]["style"] += ",filled"
             graph.nodes[n]["fillcolor"] = color
             if (
-                (max_color >= 4 and color in (1, max_color)) 
+                (max_color >= 4 and color in (1, max_color))
                 or (max_color >= 10 and color in (1, 2, max_color - 1 , max_color))
             ):
                 graph.nodes[n]["fontcolor"] = "white"

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -466,7 +466,6 @@ class TestSemanticTools(unittest.TestCase):
             self.machine_model_csx,
             self.semantics_csx_intel,
         )
-        print(dg.dg.adj)
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=3))), 1)
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=3)), 5)

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -89,6 +89,9 @@ class TestSemanticTools(unittest.TestCase):
         cls.machine_model_csx = MachineModel(
             path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "csx.yml")
         )
+        cls.machine_model_skx = MachineModel(
+            path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "skx.yml")
+        )
         cls.machine_model_tx2 = MachineModel(
             path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "tx2.yml")
         )
@@ -105,6 +108,11 @@ class TestSemanticTools(unittest.TestCase):
         cls.semantics_csx_intel = ArchSemantics(
             cls.parser_x86_intel,
             cls.machine_model_csx,
+            path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "isa/x86.yml"),
+        )
+        cls.semantics_skx_intel = ArchSemantics(
+            cls.parser_x86_intel,
+            cls.machine_model_skx,
             path_to_yaml=os.path.join(cls.MODULE_DATA_DIR, "isa/x86.yml"),
         )
         cls.semantics_aarch64 = ISASemantics(cls.parser_AArch64)
@@ -136,10 +144,10 @@ class TestSemanticTools(unittest.TestCase):
         for i in range(len(cls.kernel_x86_intel)):
             cls.semantics_csx_intel.assign_src_dst(cls.kernel_x86_intel[i])
             cls.semantics_csx_intel.assign_tp_lt(cls.kernel_x86_intel[i])
-        cls.semantics_csx_intel.normalize_instruction_forms(cls.kernel_x86_intel_memdep)
+        cls.semantics_skx_intel.normalize_instruction_forms(cls.kernel_x86_intel_memdep)
         for i in range(len(cls.kernel_x86_intel_memdep)):
-            cls.semantics_csx_intel.assign_src_dst(cls.kernel_x86_intel_memdep[i])
-            cls.semantics_csx_intel.assign_tp_lt(cls.kernel_x86_intel_memdep[i])
+            cls.semantics_skx_intel.assign_src_dst(cls.kernel_x86_intel_memdep[i])
+            cls.semantics_skx_intel.assign_tp_lt(cls.kernel_x86_intel_memdep[i])
         cls.semantics_tx2.normalize_instruction_forms(cls.kernel_AArch64)
         for i in range(len(cls.kernel_AArch64)):
             cls.semantics_tx2.assign_src_dst(cls.kernel_AArch64[i])
@@ -502,12 +510,16 @@ class TestSemanticTools(unittest.TestCase):
         dg = KernelDG(
             self.kernel_x86_intel_memdep,
             self.parser_x86_intel,
-            self.machine_model_csx,
-            self.semantics_csx_intel,
+            self.machine_model_skx,
+            self.semantics_skx_intel,
         )
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=3)), {6, 8})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {10, 12})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {10, 12})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=18)), {18.875})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=18.875)), {19})
+        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=19)), set())
         with self.assertRaises(ValueError):
             dg.get_dependent_instruction_forms()
         # test dot creation

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -516,7 +516,6 @@ class TestSemanticTools(unittest.TestCase):
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=3)), {6, 8})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {10, 12})
-        self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=5)), {10, 12})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=18)), {18.875})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=18.875)), {19})
         self.assertEqual(set(dg.get_dependent_instruction_forms(line_number=19)), set())

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -458,7 +458,7 @@ class TestSemanticTools(unittest.TestCase):
         #   /  /
         #  4  /
         #    /
-        #  5.1
+        #  4.875
         #
         dg = KernelDG(
             self.kernel_x86_intel,
@@ -466,6 +466,7 @@ class TestSemanticTools(unittest.TestCase):
             self.machine_model_csx,
             self.semantics_csx_intel,
         )
+        print(dg.dg.adj)
         self.assertTrue(nx.algorithms.dag.is_directed_acyclic_graph(dg.dg))
         self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=3))), 1)
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=3)), 5)
@@ -473,8 +474,8 @@ class TestSemanticTools(unittest.TestCase):
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=4)), 5)
         self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=5))), 1)
         self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=5)), 6)
-        self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=5.1))), 1)
-        self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=5.1)), 5)
+        self.assertEqual(len(list(dg.get_dependent_instruction_forms(line_number=4.875))), 1)
+        self.assertEqual(next(dg.get_dependent_instruction_forms(line_number=4.875)), 5)
         self.assertEqual(list(dg.get_dependent_instruction_forms(line_number=6)), [])
         self.assertEqual(list(dg.get_dependent_instruction_forms(line_number=7)), [])
         self.assertEqual(list(dg.get_dependent_instruction_forms(line_number=8)), [])


### PR DESCRIPTION
Consider the following code snippet on Zen3, in the Intel syntax:
```
	shl	rax, 5
	subsd	xmm10, QWORD PTR [rax+r8]
	movsd	xmm7, QWORD PTR [rax+r8+16]
```
Prior to this PR, OSACA would generate a LOAD node to represent the memory reference of the `subsd` instruction, but would (incorrectly) assume that the LOAD was independent from every other instruction.  This resulted in a graph like this:

![bad_load](https://github.com/user-attachments/assets/c960477c-3711-4973-851e-d1f914731813)

Note how the LOAD looks like it can be executed on the first day of creation, when in reality it depends on the computation of `rax`.  Another way to look at it is that the subtraction above should not differ much from a sequence of `movsd` to load the memory location followed by `subsd` between registers.

With this PR the LOAD is correctly depending on the result of the `shl`, with significant changes to the critical path:

![good_load](https://github.com/user-attachments/assets/9987451b-a8f9-49c0-9277-e4b91b7837d7)

Concretely, when checking if an instruction reads a register we distinguish "normal" reads from reads that occur as part of evaluating a memory address.  The latter is marked with the attribute "for_load" to indicate that its LOAD microinstruction is the part doing the read.  This results in a dependency being added from the producer of the register to the LOAD node.

I am also encapsulating a bit the computations of the "virtual" line number of the LOAD to make the code easier to follow.  This in turn entails minor changes to the structure of the code that displays the LOAD nodes.

*NOTE:*

This change reveals another issue, this one with the architecture definition files.  For Cascade Lake, there is a definition for `subsd` reading from memory thus:
```
- name: SUBSD
  operands:
  - class: memory
    base: '*'
    offset: '*'
    index: '*'
    scale: '*'
  - class: register
    name: xmm
  latency: 4
  port_pressure: [[1, '015'], [1, '23'], [1, [2D, 3D]]]
  throughput: 0.5
  uops: 2                
```
While the pressure on ports 2 and 3 is correct (cf. Agner Fog), the latency is possibly incorrect in the case where the load cannot be executed early enough.  In the example above, the latency should really be 8 cycles.  For this reason, it seems preferable to never put entries for reading from memory in the tables, and always make the LOAD microoperation explicit.

Since revisiting the architecture definition files is out of scope for this PR, I am changing some tests to use Skylake, which doesn't have the problem.