### PR TITLE
Remove duplicate throughput call and change string literal check to allow negative offsets

### DIFF
--- a/osaca/osaca.py
+++ b/osaca/osaca.py
@@ -398,7 +398,6 @@ def inspect(args, output_file=sys.stdout):
     # Do optimal schedule for kernel throughput if wished
     if not args.fixed:
         semantics.assign_optimal_throughput(kernel)
-        semantics.assign_optimal_throughput(kernel)
 
     # Create DiGrahps
     kernel_graph = KernelDG(

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -398,7 +398,7 @@ class ParserX86Intel(ParserX86):
             # outputs.
             + pp.Literal(":")
             + identifier.setResultsName("identifier")
-            + pp.Optional(pp.Literal("+") + immediate.setResultsName("displacement"))
+            + pp.Optional(operator_displacement + immediate.setResultsName("displacement"))
         ).setResultsName("offset_expression")
         ptr_expression = pp.Group(
             data_type

--- a/osaca/parser/parser_x86intel.py
+++ b/osaca/parser/parser_x86intel.py
@@ -742,7 +742,7 @@ class ParserX86Intel(ParserX86):
             if "displacement" in offset_expression
             else None
         )
-        if displacement and "operator_disp" == "-":
+        if displacement and offset_expression.get("operator_disp") == "-":
             displacement.value *= -1
         identifier = self.process_identifier(offset_expression.identifier)
         identifier.offset = displacement

--- a/tests/test_parser_x86intel.py
+++ b/tests/test_parser_x86intel.py
@@ -105,6 +105,8 @@ class TestParserX86Intel(unittest.TestCase):
         instr14 = "vaddsd  xmm0, xmm0, QWORD PTR [rdx+8+rax*8]"
         instr15 = "vextractf128 xmm1, ymm2, 0x2"
         instr16 = "vmovupd xmm0, [rax+123R]"
+        instr17 = "\tlea\trcx, OFFSET FLAT:??_R0M@8-4"
+        instr18 = "\tlea\trcx, OFFSET FLAT:foo+ -4"
 
         parsed_1 = self.parser.parse_instruction(instr1)
         parsed_2 = self.parser.parse_instruction(instr2)
@@ -122,6 +124,8 @@ class TestParserX86Intel(unittest.TestCase):
         parsed_14 = self.parser.parse_instruction(instr14)
         parsed_15 = self.parser.parse_instruction(instr15)
         parsed_16 = self.parser.parse_instruction(instr16)
+        parsed_17 = self.parser.parse_instruction(instr17)
+        parsed_18 = self.parser.parse_instruction(instr18)
 
         self.assertEqual(parsed_1.mnemonic, "sub")
         self.assertEqual(parsed_1.operands[0], RegisterOperand(name="RSP"))
@@ -235,6 +239,20 @@ class TestParserX86Intel(unittest.TestCase):
         self.assertEqual(
             parsed_16.operands[1],
             MemoryOperand(base=RegisterOperand(name="RAX"), offset=ImmediateOperand(value=291)),
+        )
+
+        self.assertEqual(parsed_17.mnemonic, "lea")
+        self.assertEqual(parsed_17.operands[0], RegisterOperand(name="RCX"))
+        self.assertEqual(
+            parsed_17.operands[1],
+            MemoryOperand(offset=IdentifierOperand(name="??_R0M@8", offset=ImmediateOperand(value=-4))),
+        )
+
+        self.assertEqual(parsed_18.mnemonic, "lea")
+        self.assertEqual(parsed_18.operands[0], RegisterOperand(name="RCX"))
+        self.assertEqual(
+            parsed_18.operands[1],
+            MemoryOperand(offset=IdentifierOperand(name="foo", offset=ImmediateOperand(value=-4))),
         )
 
     def test_parse_line(self):


### PR DESCRIPTION
The optimal throughput calculation is invoked twice during the inspect() routine which seems to be unecessary.

In the x86 Intel parser code, there seems to be a string literal check that should instead be a dictionary value conditional
`if displacement and "operator_disp" == "-":`
This results in instructions with negative memory offsets being parsed incorrectly, for example
`"\tlea\trcx, OFFSET FLAT:??_R0M@8-4"`