### PR TITLE
Fixes to the x86 and Zen3 configuration files

### DIFF
--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -2897,6 +2897,21 @@ instruction_forms:
           name: "xmm"
           source: true
           destination: true
+    - name: mul
+      operands:
+        - class: "register"
+          name: "gpr"
+          source: true
+          destination: false
+      hidden_operands:
+        - class: "register"
+          name: "rdx"
+          source: false
+          destination: true
+        - class: "register"
+          name: "rax"
+          source: true
+          destination: true
     - name: mulsd
       operands:
         - class: "register"

--- a/osaca/data/isa/x86.yml
+++ b/osaca/data/isa/x86.yml
@@ -4025,7 +4025,7 @@ instruction_forms:
           source: true
           destination: false
       # TODO sets MXCSR
-    - name: [vfmadd132pd, vfmadd213pd, vfmadd231pd]
+    - name: [vfmadd132pd, vfmadd213pd, vfmadd231pd, vfnmadd132pd, vfnmadd213pd, vfnmadd231pd]
       operands:
         - class: "register"
           name: "*"
@@ -4053,7 +4053,7 @@ instruction_forms:
           name: "*"
           source: true
           destination: true
-    - name: [vfmadd132sd, vfmadd213sd, vfmadd231sd]
+    - name: [vfmadd132sd, vfmadd213sd, vfmadd231sd, vfnmadd132sd, vfnmadd213sd, vfnmadd231sd]
       operands:
         - class: "register"
           name: "xmm"
@@ -4081,7 +4081,7 @@ instruction_forms:
           name: "xmm"
           source: true
           destination: true
-    - name: [vfmaddsub132pd, vfmaddsub213pd, vfmaddsub231pd]
+    - name: [vfmaddsub132pd, vfmaddsub213pd, vfmaddsub231pd, vfnmaddsub132pd, vfnmaddsub213pd, vfnmaddsub231pd]
       operands:
         - class: "register"
           name: "*"

--- a/osaca/data/zen3.yml
+++ b/osaca/data/zen3.yml
@@ -12,7 +12,7 @@ store_throughput:
 - {src: gpr, base: gpr, index: "*", offset: "*", scale: "*", port_pressure:  [[1, ['12', '13']]]}
 - {src: xmm, base: gpr, index: "*", offset: "*", scale: "*", port_pressure:  [[1, ['4']], [1, ['13']]]}
 - {src: ymm, base: gpr, index: "*", offset: "*", scale: "*", port_pressure:  [[1, ['4']], [1, ['13']]]}
-store_throughput_default: [1 ,['13']]
+store_throughput_default: [[1 ,['13']]]
 store_to_load_forward_latency: 0.0  # JH: according to Agner Fog "little or no penalty"
 hidden_loads: false
 ports: ['0', '1', '2', '3', DV0, DV1, '4', '5', '6', '7', '8', 8DV, '9', '10', '11', '12', '13']

--- a/osaca/data/zen3.yml
+++ b/osaca/data/zen3.yml
@@ -4781,6 +4781,18 @@ instruction_forms:
   port_pressure: [[1, '23'], [1, ['12', '13']]]  # ibench
   throughput: 0.5                                # ibench
   uops: 2                                        # ibench
+- name: [roundss, roundsd, roundps, roundpd]     # Agner Fog.
+  operands:
+  - class: immediate
+    imd: int
+  - class: register
+    name: xmm
+  - class: register
+    name: xmm
+  latency: 3
+  port_pressure: [[1, '23']]
+  throughput: 0.5
+  uops: 1
 - name: mul                  # asmbench
   operands:                  # asmbench
   - class: register          # asmbench

--- a/osaca/data/zen3.yml
+++ b/osaca/data/zen3.yml
@@ -4771,7 +4771,7 @@ instruction_forms:
   port_pressure: [[1, '6789']]  # docs
   throughput: 0.25              # docs
   uops: 1                       # docs
-- name: [vucomiss, vucomisd]                      # ibench
+- name: [ucomiss, ucomisd]                       # ibench
   operands:                                      # ibench
   - class: register                              # ibench
     name: xmm                                    # ibench
@@ -5193,7 +5193,7 @@ instruction_forms:
   port_pressure: [[1, '23'], [1, '1']]  # uops.info
   throughput: 1.0                       # uops.info
   uops: 2                               # uops.info
-- name: [vcomiss, vcomisd]               # uops.info
+- name: [comiss, comisd]                # uops.info
   operands:                             # uops.info
   - class: register                     # uops.info
     name: xmm                           # uops.info

--- a/osaca/data/zen3.yml
+++ b/osaca/data/zen3.yml
@@ -4527,6 +4527,8 @@ instruction_forms:
     name: xmm                                         # asmbench
   - class: register                                   # asmbench
     name: xmm                                         # asmbench
+  - class: register                                   # asmbench
+    name: xmm                                         # asmbench
   latency: 1                                          # asmbench
   port_pressure: [[1, '0123']]                        # asmbench
   throughput: 0.25                                    # asmbench
@@ -4616,7 +4618,7 @@ instruction_forms:
   port_pressure: [[1, '1']]  # uops.info
   throughput: 1.0            # uops.info
   uops: 1                    # uops.info
-- name: [vxorps, vxorpd]                  # asmbench
+- name: [vorps, vorpd, vxorps, vxorpd]                  # asmbench
   operands:                     # asmbench
   - class: register             # asmbench
     name: xmm                   # asmbench
@@ -4628,7 +4630,7 @@ instruction_forms:
   port_pressure: [[1, '0123']]  # asmbench
   throughput: 0.25              # asmbench
   uops: 1                       # asmbench
-- name: [vxorps, vxorpd]                  # asmbench
+- name: [vorps, vorpd, vxorps, vxorpd]                  # asmbench
   operands:                     # asmbench
   - class: register             # asmbench
     name: ymm                   # asmbench


### PR DESCRIPTION
Hello @JanLJL - I realized that I had changes in my fork that I never upstreamed so I am going to do so now, hopefully in reasonably small PRs for ease of reviewing.  This is the first such PR.

1. General x86 changes:
    1. Add support for the `vfnmadd` instructions, which work just like `vfmadd`.
    2. Add support for the `mul` instruction (unsigned multiplication).
2. Changes for the Zen3 architecture:
    1. Fix a typo in the declaration of `store_throughput_default`.
    2. Add a missing third `xmm` operand to the `vpand` instruction and friends.
    3. Add the `vorp` instructions similar to `vxorp`.
    4. Add the `round` instructions based on data provided by Agner Fog.
    5. Define latency for `ucomiss`/`comiss`, not `vucomiss`/`vcomiss`, for consistency with the x86 ISA.