### PR TITLE
Add tooltips to the graph, showing the entire instruction or a dependency

### DIFF
--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -635,6 +635,7 @@ class KernelDG(nx.DiGraph):
         graph.graph["node"] = {"colorscheme": colorscheme}
         graph.graph["edge"] = {"colorscheme": colorscheme}
         for n, color in node_colors.items():
+            color = min(color, max_color)
             if "style" not in graph.nodes[n]:
                 graph.nodes[n]["style"] = "filled"
             else:
@@ -645,6 +646,7 @@ class KernelDG(nx.DiGraph):
             ):
                 graph.nodes[n]["fontcolor"] = "white"
         for (u, v), color in edge_colors.items():
+            color = min(color, max_color)
             # The backward edge of the cycle is represented as the corresponding forward
             # edge with the attribute dir=back.
             edge = graph.edges[u, v] if (u, v) in graph.edges else graph.edges[v, u]

--- a/osaca/semantics/kernel_dg.py
+++ b/osaca/semantics/kernel_dg.py
@@ -110,7 +110,7 @@ class KernelDG(nx.DiGraph):
         # 1. find edges (to dependend further instruction)
         # 2. get LT value and set as edge weight
         for i, instruction_form in enumerate(kernel):
-            for dep, dep_flags in self.find_depending(
+            for dep, operand, dep_flags in self.find_depending(
                 instruction_form, kernel[i + 1 :], flag_dependencies
             ):
                 # print(instruction_form.line_number,"\t",dep.line_number,"\n")
@@ -128,12 +128,14 @@ class KernelDG(nx.DiGraph):
                         instruction_form.line_number,
                         loads[dep.line_number],
                         latency=edge_weight,
+                        operand=operand
                     )
                 else:
                     dg.add_edge(
                         instruction_form.line_number,
                         dep.line_number,
                         latency=edge_weight,
+                        operand=operand
                     )
 
                 dg.nodes[dep.line_number]["instruction_form"] = dep
@@ -216,11 +218,14 @@ class KernelDG(nx.DiGraph):
 
         paths_set = set()
         for path in all_paths:
+            loop_carrying_operand = None
             lat_sum = 0.0
             # extend path by edge bound latencies (e.g., store-to-load latency)
             lat_path = []
             for s, d in nx.utils.pairwise(path):
                 edge_lat = dg.edges[s, d]["latency"]
+                if s <= offset and d > offset and "operand" in dg.edges[s, d]:
+                    loop_carrying_operand = dg.edges[s, d]["operand"]
                 # map source node back to original line numbers
                 if s > offset:
                     s -= offset
@@ -235,12 +240,12 @@ class KernelDG(nx.DiGraph):
                 continue
             paths_set.add(tuple(lat_path))
 
-            loopcarried_deps.append((lat_sum, lat_path))
+            loopcarried_deps.append((lat_sum, lat_path, loop_carrying_operand))
         loopcarried_deps.sort(reverse=True)
 
         # map lcd back to nodes
         loopcarried_deps_dict = {}
-        for lat_sum, involved_lines in loopcarried_deps:
+        for lat_sum, involved_lines, loop_carrying_operand in loopcarried_deps:
             dict_key = "-".join([str(il[0]) for il in involved_lines])
             loopcarried_deps_dict[dict_key] = {
                 "root": self._get_node_by_lineno(dg, involved_lines[0][0]),
@@ -248,6 +253,7 @@ class KernelDG(nx.DiGraph):
                     (self._get_node_by_lineno(dg, ln), lat) for ln, lat in involved_lines
                 ],
                 "latency": lat_sum,
+                "operand": loop_carrying_operand
             }
         return loopcarried_deps_dict
 
@@ -300,7 +306,8 @@ class KernelDG(nx.DiGraph):
         :param flag_dependencies: indicating if dependencies of flags should be considered,
                                   defaults to `False`
         :type flag_dependencies: boolean, optional
-        :returns: iterator if all directly dependent instruction forms and according flags
+        :returns: iterator of tuples (directly dependent instruction form, operand creating the
+                  dependency, properties of the dependency)
         """
         if instruction_form.semantic_operands is None:
             return
@@ -328,14 +335,14 @@ class KernelDG(nx.DiGraph):
                             dep_flags = ["p_indexed"]
                         if read_kind == KernelDG.ReadKind.READ_FOR_LOAD:
                             dep_flags += ["for_load"]
-                        yield instr_form, dep_flags
+                        yield instr_form, dst, dep_flags
                     # write to register -> abort
                     if self.is_written(dst, instr_form):
                         break
                 if isinstance(dst, FlagOperand) and flag_dependencies:
                     # read of flag
                     if self.is_read(dst, instr_form):
-                        yield instr_form, []
+                        yield instr_form, dst, []
                     # write to flag -> abort
                     if self.is_written(dst, instr_form):
                         break
@@ -359,7 +366,7 @@ class KernelDG(nx.DiGraph):
                     #      and pass to is_memload and is_memstore to consider relevance.
                     # load from same location (presumed)
                     if self.is_memload(dst, instr_form, register_changes):
-                        yield instr_form, ["storeload_dep"]
+                        yield instr_form, dst, ["storeload_dep"]
                     # store to same location (presumed)
                     if self.is_memstore(dst, instr_form, register_changes):
                         break
@@ -580,6 +587,7 @@ class KernelDG(nx.DiGraph):
             graph.edges[min_line_number, max_line_number]["latency"] = [
                 lat for x, lat in lcd[dep]["dependencies"] if x.line_number == max_line_number
             ]
+            graph.edges[min_line_number, max_line_number]["operand"] = lcd[dep]["operand"]
 
         # add label to edges
         for e in graph.edges:
@@ -652,7 +660,28 @@ class KernelDG(nx.DiGraph):
             edge = graph.edges[u, v] if (u, v) in graph.edges else graph.edges[v, u]
             edge["color"] = color
 
+        for ln, node in graph.nodes.items():
+            node["tooltip"] = self._get_node_by_lineno(graph, ln).line
+        for edge in graph.edges.values():
+            if "operand" in edge:
+                operand = edge["operand"]
+                tooltip = None
+                if isinstance(operand, RegisterOperand) or isinstance(operand, FlagOperand):
+                    tooltip = operand.name
+                elif isinstance(operand, MemoryOperand):
+                    tooltip = "(memory)"
+                if tooltip:
+                    edge["tooltip"] = tooltip
+                    edge["labeltooltip"] = tooltip
         # rename node from [idx] to [idx mnemonic] and add shape
+        comments = [
+            n for n, node in graph.nodes.items()
+            if node["instruction_form"].comment is not None
+            and not node["instruction_form"].mnemonic
+            and not node["instruction_form"].label
+            and not node["instruction_form"].directive
+        ]
+        graph.remove_nodes_from(comments)
         mapping = {}
         for n in graph.nodes:
             node = graph.nodes[n]["instruction_form"]
@@ -661,7 +690,6 @@ class KernelDG(nx.DiGraph):
             else:
                 label = "label" if node.label is not None else None
                 label = "directive" if node.directive is not None else label
-                label = "comment" if node.comment is not None and label is None else label
                 mapping[n] = "{}: {}".format(n, label)
                 graph.nodes[n]["fontname"] = "italic"
                 graph.nodes[n]["fontsize"] = 11.0


### PR DESCRIPTION
Also:
1. Limit the number of colours to avoid "cycling" which is confusing (very hot paths look very cold).
2. Don't display the nodes labelled `"comment"` as they have no dependency and provide no useful information, they just clutter the graph.

#### Tooltip for an instruction
With the cursor on the `vnfmadd132sd` rectangle:

<img width="670" height="246" alt="tooltip" src="https://github.com/user-attachments/assets/75bbd134-cf03-4f23-9dc7-1ae293f53290" />

#### Tooltip for a dependency
With the cursor on the arrow between the `vmovupd` and `vnfmadd132sd` rectangles:

<img width="664" height="208" alt="tooltip2" src="https://github.com/user-attachments/assets/7694f573-c6f3-4ae5-8d56-cd5ab751b796" />
